### PR TITLE
Feature/mimic seperate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,15 @@ set(FNALCore_SOVERSION "0.1.0")
 set(FNALCore_DEBUG_POSTFIX "d")
 
 #-----------------------------------------------------------------------
+# Submodule versions - by hand because these can only be derived
+# from UPS files...
+#
+set(cpp0x_VERSION "1.4.9")
+set(cetlib_VERSION "1.9.0")
+set(fhiclcpp_VERSION "3.3.0")
+set(messagefacility_VERSION "1.14.0")
+
+#-----------------------------------------------------------------------
 # Standard and Custom CMake Modules
 #
 list(INSERT CMAKE_MODULE_PATH 0
@@ -143,6 +152,7 @@ endif()
 #-----------------------------------------------------------------------
 # Install support files
 #
+# - FNALCore
 configure_package_config_file(
   cmake/FNALCoreConfig.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/FNALCoreConfig.cmake
@@ -163,6 +173,25 @@ install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/FNALCoreConfigVersion.cmake
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/FNALCore-${FNALCore_VERSION}
   )
+
+# - Submodule aliasing
+foreach(_sm cpp0x cetlib fhiclcpp messagefacility)
+  configure_file(
+    cmake/${_sm}Config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/${_sm}Config.cmake
+    @ONLY
+    )
+  write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/${_sm}ConfigVersion.cmake
+    VERSION ${${_sm}_VERSION}
+    COMPATIBILITY AnyNewerVersion
+    )
+  install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/${_sm}Config.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/${_sm}ConfigVersion.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${_sm}-${${_sm}_VERSION}
+    )
+endforeach()
 
 #-----------------------------------------------------------------------
 # Package

--- a/FNALCore/messagefacility_module.cmake
+++ b/FNALCore/messagefacility_module.cmake
@@ -208,11 +208,16 @@ install(TARGETS
 #-----------------------------------------------------------------------
 # Annnnd.... We have to build the test executable that for some surely
 # very good reason resides in the library sources...
-if(FNALCore_ENABLE_TESTING)
-  add_executable(ELdestinationTester
-    ${messagefacility_INCLUDE_DIR}/MessageService/ELdestinationTester.h
-    ${messagefacility_INCLUDE_DIR}/MessageService/ELdestinationTester.cc
-    )
-  target_link_libraries(ELdestinationTester FNALCore)
-endif()
+# Except as per Redmine 8020, it's an actual application, so better
+# install and export it!!
+add_executable(ELdestinationTester
+  ${messagefacility_INCLUDE_DIR}/MessageService/ELdestinationTester.h
+  ${messagefacility_INCLUDE_DIR}/MessageService/ELdestinationTester.cc
+  )
+target_link_libraries(ELdestinationTester FNALCore)
+install(TARGETS ELdestinationTester
+  EXPORT FNALCoreExports
+  DESTINATION ${CMAKE_INSTALL_BINDIR}
+  COMPONENT Development
+  )
 

--- a/FNALCore/messagefacility_module.cmake
+++ b/FNALCore/messagefacility_module.cmake
@@ -149,6 +149,36 @@ add_library(obj-messagefacility OBJECT
   ${MessageFacility_Utilities_SOURCES}
   )
 
+# - New plugins. Need to link to FNALCore eventually
+# There is an oddity here - there is (surprise, surprise...) yet
+# another library "MF_FileFormat", but it lives under the mfplugins
+# namespace and only appears used by "file_mfPlugin" and "file_mfStatsPlugin"
+# Not clear if this is private functionality of MessageFacility, or intended
+# for use by other plugins (header does not appear to be installed, but
+# with cetbuildtools who knows).
+# - TEMP: Just build the core ones
+add_library(messagefacility_cout_mfPlugin SHARED
+  ${messagefacility_INCLUDE_DIR}/MessageService/plugins/cout_mfPlugin.cc)
+target_link_libraries(messagefacility_cout_mfPlugin FNALCore)
+
+add_library(messagefacility_cerr_mfPlugin SHARED
+  ${messagefacility_INCLUDE_DIR}/MessageService/plugins/cerr_mfPlugin.cc)
+target_link_libraries(messagefacility_cerr_mfPlugin FNALCore)
+
+add_library(messagefacility_syslog_mfPlugin SHARED
+  ${messagefacility_INCLUDE_DIR}/MessageService/plugins/syslog_mfPlugin.cc)
+target_link_libraries(messagefacility_syslog_mfPlugin FNALCore)
+
+add_library(messagefacility_cout_mfStatsPlugin SHARED
+  ${messagefacility_INCLUDE_DIR}/MessageService/plugins/cout_mfStatsPlugin.cc)
+target_link_libraries(messagefacility_cout_mfStatsPlugin FNALCore)
+
+add_library(messagefacility_cerr_mfStatsPlugin SHARED
+  ${messagefacility_INCLUDE_DIR}/MessageService/plugins/cerr_mfStatsPlugin.cc)
+target_link_libraries(messagefacility_cerr_mfStatsPlugin FNALCore)
+
+
+
 # TEMP local install of headers
 install(FILES ${MessageFacility_Utilities_HEADERS}
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/FNALCore/messagefacility/Utilities
@@ -162,4 +192,27 @@ install(FILES ${MessageLogger_HEADERS}
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/FNALCore/messagefacility/MessageLogger
   COMPONENT Development
   )
+
+# Also install plugins, though we don't need to export these because
+# they're not designed to be linked to
+install(TARGETS
+  messagefacility_cout_mfPlugin
+  messagefacility_cerr_mfPlugin
+  messagefacility_syslog_mfPlugin
+  messagefacility_cout_mfStatsPlugin
+  messagefacility_cerr_mfStatsPlugin
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  COMPONENT Runtime
+  )
+
+#-----------------------------------------------------------------------
+# Annnnd.... We have to build the test executable that for some surely
+# very good reason resides in the library sources...
+if(FNALCore_ENABLE_TESTING)
+  add_executable(ELdestinationTester
+    ${messagefacility_INCLUDE_DIR}/MessageService/ELdestinationTester.h
+    ${messagefacility_INCLUDE_DIR}/MessageService/ELdestinationTester.cc
+    )
+  target_link_libraries(ELdestinationTester FNALCore)
+endif()
 

--- a/README.md
+++ b/README.md
@@ -46,19 +46,22 @@ Installation
 Requirements
 ------------
 - [CMake](http://www.cmake.org) 2.8.12 or above
-- [C++0X/11](http://isocpp.org) compliant compiler
-  - The [CheckCXX11Features](https://github.com/drbenmorgan/CheckCXX11Features) package is used to check for known C++0X/11 features.
+- [C++11/14](http://isocpp.org) compliant compiler
+  - The [CheckCXX11Features](https://github.com/drbenmorgan/CheckCXX11Features) package is used to check for known C++0X/11 features and compiler
+    flags.
   - The `cpp0x` module provides minimal implementations of some
     C++11 features, but is not complete.
   - Boost implementations are used where neccessary.
   - Features that the compiler/standard library *must* provide include
     (not complete as yet):
     - `emplace` member functions of `std::` collections.
+  - Note that *by default* FNALCore is built with the best available
+    standard, so C++1y/14 if available, then C++11, then C++0x.
 - [Boost](http://www.boost.org) 1.55 or higher, with `filesystem`,
   `system`, `regex` and `thread` libraries compiled against C++11.
   If you want to run FNALCore's unit tests, the Boost `unit_test` library
   is also needed.
-  - NB: the C++11 compatibility of the found Boost is *not* checked, but
+  - NB: the C++11/14 compatibility of the found Boost is *not* checked, but
     an ABI incompatible Boost should cause the unit tests to fail. It
     should be noted that as a robust ABI checks are tricky to implement,
     it is up to *you*, not the buildsystem, to point to the right Boost.
@@ -66,6 +69,7 @@ Requirements
   in `fhiclcpp`.
 - [Doxygen](http://www.doxygen.org) 1.8 or higher for building FNALCore's
   documentation.
+
 
 How to Install
 --------------
@@ -111,6 +115,10 @@ CMAKE_INSTALL_PREFIX/
 |  +- libFNALCore.so
 |  +- cmake/
 |     +- FNALCore-<VERSION>
+|     +- cpp0x-<cpp0xVERSION>
+|     +- cetlib-<cetlibVERSION>
+|     +- fhiclcpp-<fhiclcppVERSION>
+|     +- messagefacility-<messagefacilityVERSION>
 +- share/
    +- doc/
       +- FNALCore/
@@ -168,6 +176,39 @@ in a non-relocatable path being encoded in the FNALCore support files.
 This can be resolved when CMake's `FindBoost` module supports imported
 targets, or a wrapper can be written.
 
+
+Adapting Existing CMake Build Scripts
+-------------------------------------
+If your CMake build scripts use `find_package` calls to locate the
+old-style separate components, e.g.
+
+```cmake
+find_package(cetlib X.Y.Z REQUIRED)
+```
+
+then no changes should be needed. FNALCore supplies adaptor modules to
+mimic the separate packages (with the bonus that all inter-package
+dependencies are automatically handled as soon as the first package is
+found). Package location is handled identically as for FNALCore, so if
+you have installed FNALCore to a non standard location, you may need to
+set `CMAKE_PREFIX_PATH`, or `<component>_DIR` (e.g. `cetlib_DIR`).
+
+Each modular config provides canonical CMake variables for header paths
+and libraries to be linked to. For example
+simp
+
+```cmake
+include_directories(${cetlib_INCLUDE_DIRS})
+
+add_executable(foo foo.cc)
+target_link_libraries(foo ${cetlib_LIBRARIES})
+```
+
+Note that this style is provided only as an assistance step in migration
+to full FNALCore. The adaption scripts simply provide aliases to the
+underlying FNALCore library and headers.
+
+
 Header Paths and Adapting Existing Code
 ---------------------------------------
 Provided you have the `<CMAKE_INSTALL_PREFIX>/include/FNALCore` directory
@@ -184,6 +225,7 @@ Any existing code you have written using separately compiled cpp0x,
 cetlib etc is API compatible with FNALCore. The only change that is
 required is to use `find_package(FNALCore)` and to link any binary against
 the FNALCore library instead of the separate cpp0x, cetlib etc libraries.
+
 
 Documentation
 -------------

--- a/cmake/cetlibConfig.cmake.in
+++ b/cmake/cetlibConfig.cmake.in
@@ -1,0 +1,22 @@
+# - cetlib CMake package configuration file, aliasing to FNALCore
+
+# Finding FNALCore will handle everything, then we provide workarounds
+# It will always be one level down from this file, and we know the version
+find_package(FNALCore @FNALCore_VERSION@ EXACT REQUIRED NO_DEFAULT_PATH
+  PATHS "${CMAKE_CURRENT_LIST_DIR}/..")
+
+# Can't alias an imported target, so use variables
+set(cetlib_LIBRARIES FNALCore::FNALCore)
+get_property(cetlib_INCLUDE_DIRS
+  TARGET FNALCore::FNALCore
+  PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+  )
+
+# - API/ABI details
+set(cetlib_VERSION @cetlib_VERSION@)
+set(cetlib_CXX_COMPILER_ID "@CMAKE_CXX_COMPILER_ID@")
+set(cetlib_CXX_COMPILER_VERSION "@CMAKE_CXX_COMPILER_VERSION@")
+set(cetlib_CXX_STDLIB_ID "@CXX_STDLIB_VENDOR@")
+set(cetlib_CXX_STDLIB_VERSION "@CXX_STDLIB_VERSION@")
+set(cetlib_CXX_FLAGS "@CMAKE_CXX_FLAGS@")
+

--- a/cmake/cpp0xConfig.cmake.in
+++ b/cmake/cpp0xConfig.cmake.in
@@ -1,0 +1,22 @@
+# - cpp0x CMake package configuration file, aliasing to FNALCore
+
+# Finding FNALCore will handle everything, then we provide workarounds
+# It will always be one level down from this file, and we know the version
+find_package(FNALCore @FNALCore_VERSION@ EXACT REQUIRED NO_DEFAULT_PATH
+  PATHS "${CMAKE_CURRENT_LIST_DIR}/..")
+
+# Can't alias an imported target, so use variables
+set(cpp0x_LIBRARIES FNALCore::FNALCore)
+get_property(cpp0x_INCLUDE_DIRS
+  TARGET FNALCore::FNALCore
+  PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+  )
+
+# - API/ABI details
+set(cpp0x_VERSION @cpp0x_VERSION@)
+set(cpp0x_CXX_COMPILER_ID "@CMAKE_CXX_COMPILER_ID@")
+set(cpp0x_CXX_COMPILER_VERSION "@CMAKE_CXX_COMPILER_VERSION@")
+set(cpp0x_CXX_STDLIB_ID "@CXX_STDLIB_VENDOR@")
+set(cpp0x_CXX_STDLIB_VERSION "@CXX_STDLIB_VERSION@")
+set(cpp0x_CXX_FLAGS "@CMAKE_CXX_FLAGS@")
+

--- a/cmake/fhiclcppConfig.cmake.in
+++ b/cmake/fhiclcppConfig.cmake.in
@@ -1,0 +1,22 @@
+# - fhiclcpp CMake package configuration file, aliasing to FNALCore
+
+# Finding FNALCore will handle everything, then we provide workarounds
+# It will always be one level down from this file, and we know the version
+find_package(FNALCore @FNALCore_VERSION@ EXACT REQUIRED NO_DEFAULT_PATH
+  PATHS "${CMAKE_CURRENT_LIST_DIR}/..")
+
+# Can't alias an imported target, so use variables
+set(fhiclcpp_LIBRARIES FNALCore::FNALCore)
+get_property(fhiclcpp_INCLUDE_DIRS
+  TARGET FNALCore::FNALCore
+  PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+  )
+
+# - API/ABI details
+set(fhiclcpp_VERSION @fhiclcpp_VERSION@)
+set(fhiclcpp_CXX_COMPILER_ID "@CMAKE_CXX_COMPILER_ID@")
+set(fhiclcpp_CXX_COMPILER_VERSION "@CMAKE_CXX_COMPILER_VERSION@")
+set(fhiclcpp_CXX_STDLIB_ID "@CXX_STDLIB_VENDOR@")
+set(fhiclcpp_CXX_STDLIB_VERSION "@CXX_STDLIB_VERSION@")
+set(fhiclcpp_CXX_FLAGS "@CMAKE_CXX_FLAGS@")
+

--- a/cmake/messagefacilityConfig.cmake.in
+++ b/cmake/messagefacilityConfig.cmake.in
@@ -1,0 +1,22 @@
+# - messagefacility CMake package configuration file, aliasing to FNALCore
+
+# Finding FNALCore will handle everything, then we provide workarounds
+# It will always be one level down from this file, and we know the version
+find_package(FNALCore @FNALCore_VERSION@ EXACT REQUIRED NO_DEFAULT_PATH
+  PATHS "${CMAKE_CURRENT_LIST_DIR}/..")
+
+# Can't alias an imported target, so use variables
+set(messagefacility_LIBRARIES FNALCore::FNALCore)
+get_property(messagefacility_INCLUDE_DIRS
+  TARGET FNALCore::FNALCore
+  PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+  )
+
+# - API/ABI details
+set(messagefacility_VERSION @messagefacility_VERSION@)
+set(messagefacility_CXX_COMPILER_ID "@CMAKE_CXX_COMPILER_ID@")
+set(messagefacility_CXX_COMPILER_VERSION "@CMAKE_CXX_COMPILER_VERSION@")
+set(messagefacility_CXX_STDLIB_ID "@CXX_STDLIB_VENDOR@")
+set(messagefacility_CXX_STDLIB_VERSION "@CXX_STDLIB_VERSION@")
+set(messagefacility_CXX_FLAGS "@CMAKE_CXX_FLAGS@")
+


### PR DESCRIPTION
This is a test of using pull requests, so bear with me... This request provides
- Support for CMake find_package to enable users to locate FNALCore using aliases based on the submodules, e.g.
  
  ```
   find_package(cetlib) # finds FNALCore under the hood
  ```
- Builds missing items from messagefacility
  - New plugins
  - Remaining ELdestinationTester program. This is only used in the test suite, but its sources are located alongside the actual library code. This confusion has been reported [upstream](https://cdcvs.fnal.gov/redmine/issues/8020), but in the meantime we leave the sources where they are.

There are no changes to the subtrees, so if the fixes are o.k., I'd propose to merge into develop and then create a new revision release.
